### PR TITLE
Display commit status for each remote individually

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ omf install sushi
 * Displays `*` when there are any changes to files already being tracked in the repo.
 * Displays current branch name.
 * Branch name color changes when there are staged changes.
-* Displays number of commits current branch is ahead/behind from origin.
+* Displays number of commits current branch is ahead/behind in each remote.
 * By default it shows only the name of the current directory but it provides a flag `theme_complete_path` to display abbreviated current working directory instead.
 * Displays Time.
 

--- a/fish_greeting.fish
+++ b/fish_greeting.fish
@@ -1,5 +1,6 @@
 set -g CMD_DURATION 0
 
+function orange;		set_color -o ee5819; end
 function yellow;		set_color -o b58900; end
 function red;			set_color -o d30102; end
 function cyan;			set_color -o 2aa198; end

--- a/fish_greeting.fish
+++ b/fish_greeting.fish
@@ -1,8 +1,8 @@
 set -g CMD_DURATION 0
 
-function yellow;	    set_color -o b58900; end
-function red;       	set_color -o d30102; end
-function cyan;      	set_color -o 2aa198; end
+function yellow;		set_color -o b58900; end
+function red;			set_color -o d30102; end
+function cyan;			set_color -o 2aa198; end
 function white;			set_color -o fdf6e3; end
 function dim;			set_color -o 4f4f4f; end
 function off;			set_color -o normal; end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,12 +1,12 @@
 function fish_prompt
 	set -l symbol		"λ "
-  	set -l code 		$status
+	set -l code		$status
 
 	if git_is_repo
 
 		set -l branch			(git_branch_name ^/dev/null)
 		set -l remote			"origin"
-        	set -l ref              	(git show-ref --head --abbrev | awk '{print substr($0,0,7)}' | sed -n 1p)
+		set -l ref			(git show-ref --head --abbrev | awk '{print substr($0,0,7)}' | sed -n 1p)
 		
 		if git_is_stashed
 			echo -n -s (white)"^"(off)
@@ -17,16 +17,16 @@ function fish_prompt
 		if git_is_dirty
 			printf (white)"*"(off)
 		end
-	        
-	        if command git symbolic-ref HEAD > /dev/null ^/dev/null
-	    		if git_is_staged
+
+		if command git symbolic-ref HEAD > /dev/null ^/dev/null
+			if git_is_staged
 				printf (cyan)"$branch"(off)
-		    	else
-			    	printf (yellow)"$branch"(off)
-	    		end
-	        else
-	        	printf (dim)"$ref"(off)
-	        end
+			else
+				printf (yellow)"$branch"(off)
+			end
+		else
+			printf (dim)"$ref"(off)
+		end
 
 		if command git remote | grep $remote > /dev/null ^/dev/null
 			set -l behind_count		(echo (command git rev-list $branch..$remote/$branch ^/dev/null | wc -l | tr -d " "))

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -5,7 +5,6 @@ function fish_prompt
 	if git_is_repo
 
 		set -l branch			(git_branch_name ^/dev/null)
-		set -l remote			"origin"
 		set -l ref			(git show-ref --head --abbrev | awk '{print substr($0,0,7)}' | sed -n 1p)
 		
 		if git_is_stashed
@@ -28,9 +27,13 @@ function fish_prompt
 			printf (dim)"$ref"(off)
 		end
 
-		if command git remote | grep $remote > /dev/null ^/dev/null
+		for remote in (git remote)
 			set -l behind_count		(echo (command git rev-list $branch..$remote/$branch ^/dev/null | wc -l | tr -d " "))
 			set -l ahead_count		(echo (command git rev-list $remote/$branch..$branch ^/dev/null | wc -l | tr -d " "))
+
+			if test $ahead_count -ne 0; or test $behind_count -ne 0; and test (git remote | wc -l) -gt 1
+				echo -n -s " "(orange)$remote(off)
+			end
 
 			if test $ahead_count -ne 0
 				echo -n -s (white)" +"$ahead_count(off)


### PR DESCRIPTION
If a git repo has more than one remote, the fish prompt will show the commit status for each remote.

See the screenshot, it shows either cases:

![sushi](https://cloud.githubusercontent.com/assets/14050128/24224156/6da09b2e-0f7b-11e7-8283-ce99627a51bc.png)
