### PR TITLE
Fix empty kubernetes namespace issue

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -123,8 +123,13 @@ function fish_right_prompt
 		end
 	end
 
-	command -sq kubectl; and k8s::current_context 2>/dev/null; and begin
-		printf (yellow)"("(dim)(k8s::current_context)"/"(k8s::current_namespace)(yellow)") "(off)
+	command -sq kubectl; and k8s::current_context >/dev/null 2>/dev/null; and begin
+		set -l k8s_namespace (k8s::current_namespace)
+		if test -z "$k8s_namespace"
+			printf (yellow)"("(dim)(k8s::current_context)(yellow)") "(off)
+		else
+			printf (yellow)"("(dim)(k8s::current_context)"/$k8s_namespace"(yellow)") "(off)
+		end
 	end
 
 	if terraform::workspace


### PR DESCRIPTION
Actually it fixes two issues:
1. The `k8s::current_context` does not (or no longer) writes to `stderr`, it uses `stdout`. This was causing duplicate printing of the context name
2. The `k8s::current_namespace` function, in some cases, returns empty string. This was causing fish to print out the following error on every line in case you have `kubectl`: `printf: Expected at least 1 args, got only 0`

Signed-off-by: Ali Yousuf <aly.yousuf7@gmail.com>