### PR TITLE
Support async-prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@
 
 ## Install
 
-```fish
+```bash
 $ omf install sushi
+# or
+$ fisher umayr/sushi
 ```
 
 ## Features
@@ -27,6 +29,17 @@ $ omf install sushi
 * Displays Time.
 * Support for Terraform
 * Support for Kubernetes
+* Asynchronous prompts
+
+## Use asynchronous prompts
+This theme supports (optional) async prompts using [`acomagu/fish-async-prompt`](https://github.com/acomagu/fish-async-prompt) plugin, which gives you access to terminal without waiting for theme to completely render.
+
+To install the plugin,
+```bash
+$ omf install https://github.com/acomagu/fish-async-prompt
+# or
+$ fisher acomagu/fish-async-prompt
+```
 
 ## Screenshot
 

--- a/functions/_load_sushi.fish
+++ b/functions/_load_sushi.fish
@@ -1,30 +1,34 @@
+# Async prompt setup
+contains $async_prompt_functions left_context or set -U -a async_prompt_functions left_context
+contains $async_prompt_functions right_context or set -U -a async_prompt_functions right_context
+
 # Colors
 function orange
-    set_color -o ee5819
+	set_color -o ee5819
 end
 
 function yellow
-    set_color -o b58900
+	set_color -o b58900
 end
 
 function red
-    set_color -o d30102
+	set_color -o d30102
 end
 
 function cyan
-    set_color -o 2aa198
+	set_color -o 2aa198
 end
 
 function white
-    set_color -o fdf6e3
+	set_color -o fdf6e3
 end
 
 function dim
-    set_color -o 4f4f4f
+	set_color -o 4f4f4f
 end
 
 function off
-    set_color -o normal
+	set_color -o normal
 end
 
 # Git
@@ -58,11 +62,11 @@ end
 # Kubernetes
 
 function k8s::current_context
-    command kubectl config current-context
+	command kubectl config current-context
 end
 
 function k8s::current_namespace
-    command kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}'
+	command kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}'
 end
 
 # Terraform

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -4,55 +4,7 @@ function fish_prompt
 	set -l symbol "λ "
 	set -l code $status
 
-	if test -n "$SSH_CLIENT"
-		set -l host (hostname -s)
-		set -l who (whoami)
-		echo -n -s (red)"("(cyan)"$who"(red)":"(cyan)"$host"(red)") "(off)
-	end
-
-	if git::is_repo
-		set -l branch (git::branch_name ^/dev/null)
-		set -l ref (git show-ref --head --abbrev | awk '{print substr($0,0,7)}' | sed -n 1p)
-
-		if git::is_stashed
-			echo -n -s (white)"^"(off)
-		end
-
-		echo -n -s (red)"("(off)
-
-		if git::is_dirty
-			printf (white)"*"(off)
-		end
-
-		if command git symbolic-ref HEAD > /dev/null ^/dev/null
-			if git::is_staged
-				printf (cyan)"$branch"(off)
-			else
-				printf (yellow)"$branch"(off)
-			end
-		else
-			printf (dim)"$ref"(off)
-		end
-
-		for remote in (git remote)
-			set -l behind_count (echo (command git rev-list $branch..$remote/$branch ^/dev/null | wc -l | tr -d " "))
-			set -l ahead_count (echo (command git rev-list $remote/$branch..$branch ^/dev/null | wc -l | tr -d " "))
-
-			if test $ahead_count -ne 0; or test $behind_count -ne 0; and test (git remote | wc -l) -gt 1
-				echo -n -s " "(orange)$remote(off)
-			end
-
-			if test $ahead_count -ne 0
-				echo -n -s (white)" +"$ahead_count(off)
-			end
-
-			if test $behind_count -ne 0
-				echo -n -s (white)" -"$behind_count(off)
-			end
-		end
-
-		echo -n -s (red)") "(off)
-	end
+	left_context
 
 	if test "$code" = 0
 		echo -n -s (red)"$symbol"(off)

--- a/functions/fish_right_prompt.fish
+++ b/functions/fish_right_prompt.fish
@@ -5,28 +5,10 @@ function fish_right_prompt
 		set cwd (prompt_pwd)
 	else
 		set cwd (basename (prompt_pwd))
-
-		if git::is_repo
-			set root_folder (command git rev-parse --show-toplevel ^/dev/null)
-			set parent_root_folder (dirname $root_folder)
-			set cwd (echo $PWD | sed -e "s|$parent_root_folder/||")
-		end
 	end
 
-	command -sq kubectl; and k8s::current_context >/dev/null 2>/dev/null; and begin
-		set -l k8s_namespace (k8s::current_namespace)
-		if test -z "$k8s_namespace"
-			printf (yellow)"("(dim)(k8s::current_context)(yellow)") "(off)
-		else
-			printf (yellow)"("(dim)(k8s::current_context)"/$k8s_namespace"(yellow)") "(off)
-		end
-	end
+	right_context
 
-	if terraform::workspace
-		set terraform_workspace_name (command cat .terraform/environment)
-		printf (yellow)"("(dim)$terraform_workspace_name(yellow)") "(off)
-	end
-
-	printf (yellow)"("(dim)$cwd(yellow)") "(off)
-	printf (dim)(date +%H(yellow):(dim)%M(yellow):(dim)%S)(off)
+	echo -n -s (yellow)"("(dim)$cwd(yellow)") "(off)
+	echo -n -s (dim)(date +%H(yellow):(dim)%M(yellow):(dim)%S)(off)
 end

--- a/functions/fish_title.fish
+++ b/functions/fish_title.fish
@@ -1,3 +1,3 @@
 function fish_title
-    echo "$PWD | $_" | sed "s|$HOME|~|g"
+	echo "$PWD | $_" | sed "s|$HOME|~|g"
 end

--- a/functions/left_context.fish
+++ b/functions/left_context.fish
@@ -1,0 +1,59 @@
+_load_sushi
+
+function left_context
+	if test -n "$SSH_CLIENT"
+		set -l host (hostname -s)
+		set -l who (whoami)
+		echo -n -s (red)"("(cyan)"$who"(red)":"(cyan)"$host"(red)") "(off)
+	end
+
+	if git::is_repo
+		set -l branch (git::branch_name ^/dev/null)
+		set -l ref (git show-ref --head --abbrev | awk '{print substr($0,0,7)}' | sed -n 1p)
+
+		if git::is_stashed
+			echo -n -s (white)"^"(off)
+		end
+
+		echo -n -s (red)"("(off)
+
+		if git::is_dirty
+			echo -n -s (white)"*"(off)
+		end
+
+		if command git symbolic-ref HEAD > /dev/null ^/dev/null
+			if git::is_staged
+				echo -n -s (cyan)"$branch"(off)
+			else
+				echo -n -s (yellow)"$branch"(off)
+			end
+		else
+			echo -n -s (dim)"$ref"(off)
+		end
+
+		for remote in (git remote)
+			set -l behind_count (echo (command git rev-list $branch..$remote/$branch ^/dev/null | wc -l | tr -d " "))
+			set -l ahead_count (echo (command git rev-list $remote/$branch..$branch ^/dev/null | wc -l | tr -d " "))
+
+			if test $ahead_count -ne 0; or test $behind_count -ne 0; and test (git remote | wc -l) -gt 1
+				echo -n -s " "(orange)$remote(off)
+			end
+
+			if test $ahead_count -ne 0
+				echo -n -s (white)" +"$ahead_count(off)
+			end
+
+			if test $behind_count -ne 0
+				echo -n -s (white)" -"$behind_count(off)
+			end
+		end
+
+		echo -n -s (red)") "(off)
+	end
+end
+
+# Print grayed out last prompt while loading
+function left_context_loading_indicator -a last_prompt
+	echo -n -s "$last_prompt" | string replace -ra '\e\[[^m]*m' '' | read -l uncolored_last_prompt
+	echo -n -s (dim)"$uncolored_last_prompt"(off)
+end

--- a/functions/right_context.fish
+++ b/functions/right_context.fish
@@ -1,0 +1,28 @@
+_load_sushi
+
+function right_context
+	if test "$theme_complete_path" != "yes" && git::is_repo
+		set root_folder (command git rev-parse --show-toplevel ^/dev/null)
+		set parent_root_folder (dirname $root_folder)
+		set cwd (echo $PWD | sed -e "s|$parent_root_folder/||")
+	end
+
+	command -sq kubectl; and k8s::current_context >/dev/null 2>/dev/null; and begin
+		set -l k8s_namespace (k8s::current_namespace)
+		if test -z "$k8s_namespace"
+			echo -n -s (yellow)"("(dim)(k8s::current_context)(yellow)") "(off)
+		else
+			echo -n -s (yellow)"("(dim)(k8s::current_context)"/$k8s_namespace"(yellow)") "(off)
+		end
+	end
+
+	if terraform::workspace
+		set terraform_workspace_name (command cat .terraform/environment)
+		echo -n -s (yellow)"("(dim)$terraform_workspace_name(yellow)") "(off)
+	end
+end
+
+# Print ellipse while loading
+function right_context_loading_indicator
+	echo -n -s (dim)"… "(off)
+end


### PR DESCRIPTION
This adds support for async prompts.

Rationale: Over the time, support for a lots of new commands have been added to this theme, e.g. Terraform, Kubernetes and extra features for Git. Each of these features runs some commands and that takes time to execute. For slower CPUs, your productivity degrades because the prompt starts taking time and you have to wait before typing new commands.

This makes all of the time taking features to execute asynchronously and gives you access to prompt instantly.

To make this async thing to happen, the theme requires [`acomagu/fish-async-prompt`](https://github.com/acomagu/fish-async-prompt) to be installed. However if you do not have it installed, the theme will keep working as before.

Signed-off-by: Ali Yousuf <aly.yousuf7@gmail.com>