### PR TITLE
Fix remote ssh detection

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -4,7 +4,7 @@ function fish_prompt
 	set -l symbol "λ "
 	set -l code $status
 
-	if test -n "$ssh_client"
+	if test -n "$SSH_CLIENT"
 		set -l host (hostname -s)
 		set -l who (whoami)
 		echo -n -s (red)"("(cyan)"$who"(red)":"(cyan)"$host"(red)") "(off)


### PR DESCRIPTION
For some reason, previously `fish` used to fetch the variable even if the variable was incorrectly cased.

This PR fixes the case so that SSH detection starts working again.

Signed-off-by: Ali Yousuf <aly.yousuf7@gmail.com>