### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/functions/_load_sushi.fish
+++ b/functions/_load_sushi.fish
@@ -29,13 +29,13 @@ end
 
 # Git
 function git::is_repo
-	test -d .git; or command git rev-parse --git-dir >/dev/null ^/dev/null
+	test -d .git; or command git rev-parse --git-dir >/dev/null 2>&1
 end
 
 function git::branch_name
 	git::is_repo; and begin
-		command git symbolic-ref --short HEAD ^/dev/null;
-		or command git show-ref --head -s --abbrev | head -n1 ^/dev/null
+		command git symbolic-ref --short HEAD 2>/dev/null;
+		or command git show-ref --head -s --abbrev | head -n1 2>/dev/null
 	end
 end
 
@@ -69,7 +69,7 @@ end
 
 # Test whether this is a terraform directory by finding .tf files
 function terraform::directory
-	command find . -name '*.tf' >/dev/null ^/dev/null -maxdepth 0
+	command find . -name '*.tf' >/dev/null 2>&1 -maxdepth 0
 end
 
 function terraform::workspace

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -11,7 +11,7 @@ function fish_prompt
 	end
 
 	if git::is_repo
-		set -l branch (git::branch_name ^/dev/null)
+		set -l branch (git::branch_name 2>/dev/null)
 		set -l ref (git show-ref --head --abbrev | awk '{print substr($0,0,7)}' | sed -n 1p)
 
 		if git::is_stashed
@@ -24,7 +24,7 @@ function fish_prompt
 			printf (white)"*"(off)
 		end
 
-		if command git symbolic-ref HEAD > /dev/null ^/dev/null
+		if command git symbolic-ref HEAD > /dev/null 2>&1
 			if git::is_staged
 				printf (cyan)"$branch"(off)
 			else
@@ -35,8 +35,8 @@ function fish_prompt
 		end
 
 		for remote in (git remote)
-			set -l behind_count (echo (command git rev-list $branch..$remote/$branch ^/dev/null | wc -l | tr -d " "))
-			set -l ahead_count (echo (command git rev-list $remote/$branch..$branch ^/dev/null | wc -l | tr -d " "))
+			set -l behind_count (echo (command git rev-list $branch..$remote/$branch 2>/dev/null | wc -l | tr -d " "))
+			set -l ahead_count (echo (command git rev-list $remote/$branch..$branch 2>/dev/null | wc -l | tr -d " "))
 
 			if test $ahead_count -ne 0; or test $behind_count -ne 0; and test (git remote | wc -l) -gt 1
 				echo -n -s " "(orange)$remote(off)

--- a/functions/fish_right_prompt.fish
+++ b/functions/fish_right_prompt.fish
@@ -7,7 +7,7 @@ function fish_right_prompt
 		set cwd (basename (prompt_pwd))
 
 		if git::is_repo
-			set root_folder (command git rev-parse --show-toplevel ^/dev/null)
+			set root_folder (command git rev-parse --show-toplevel 2>/dev/null)
 			set parent_root_folder (dirname $root_folder)
 			set cwd (echo $PWD | sed -e "s|$parent_root_folder/||")
 		end


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Ref [oh-my-fish/oh-my-fish#585][2]

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585